### PR TITLE
Increasing version of zstandard to fix incompatability with ubuntu 22.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pystac-client = "^0.7.1"
 rasterio = "^1.3.0"
 shapely = "^2.0.0"
 tqdm = "^4.52.0"
-zstandard = "^0.15.0"
+zstandard = "^0.20.0"
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.25.2"


### PR DESCRIPTION
The relaxation added made a force of zstandard version of 15<x<16, which do not work with ubuntu. 
This is a test to see if increasing the version requirement fixes the issue.